### PR TITLE
Fix repositories generator

### DIFF
--- a/src/ArtifyServiceProvider.php
+++ b/src/ArtifyServiceProvider.php
@@ -36,7 +36,7 @@ class ArtifyServiceProvider extends ServiceProvider
         Filesystem::macro('transformNamespaceToLocation', function ($location) {
             $location = str_replace('\\', '/', $location);
             $filename = Arr::last(explode('/', $location));
-            return str_replace('/' . $filename, '', $location);
+            return str_replace('/' . $filename, '', lcfirst($location));
         });
         $this->app->singleton(Manager::class, function () {
             return new Manager();

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -3,6 +3,6 @@
 if (!function_exists('artify_path')) {
     function artify_path($path = null)
     {
-        return base_path('vendor/sectheater/artify/src') . DIRECTORY_SEPARATOR . ltrim($path, '/');
+        return dirname(__DIR__,1) . DIRECTORY_SEPARATOR . ltrim($path, '/');
     }
 }

--- a/src/artifies/RegisterAuthorizationCommand.php
+++ b/src/artifies/RegisterAuthorizationCommand.php
@@ -3,13 +3,11 @@ namespace Artify\Artify\Artifies;
 
 use Artify\Artify\Models\Role;
 use Illuminate\Console\Command;
-use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Filesystem\Filesystem;
 use Str;
 
 class RegisterAuthorizationCommand extends Command
 {
-    use DetectsApplicationNamespace;
     /**
      * The name and signature of the console command.
      *

--- a/src/artifies/RegisterAuthorizationCommand.php
+++ b/src/artifies/RegisterAuthorizationCommand.php
@@ -50,7 +50,7 @@ class RegisterAuthorizationCommand extends Command
         if (!count($permissions)) {
             return $this->error('Roles are not set yet, or maybe they are not an array.');
         }
-        if (config('artify.adr.enabled')) {
+        if (config('artify.is_adr')) {
             if (!count(config('artify.adr.domains'))) {
                 return $this->error('You should fill up the domains key inside config/artify.php with the domains you wish to register authorization for.');
             }
@@ -152,7 +152,7 @@ class RegisterAuthorizationCommand extends Command
                 '$this->registerPolicies();' .
                 str_repeat(
                     "\n\t\tGate::define(\'dummy-access\',\'\App\Policies\DummyPolicy@DummyAction\');",
-                    config('artify.adr.enabled') ? count($this->permissions[strtolower($this->currentDomain)]) : $this->permissions->collapse()->count()
+                    config('artify.is_adr') ? count($this->permissions[strtolower($this->currentDomain)]) : $this->permissions->collapse()->count()
                 ),
                 $this->getContent()
             )
@@ -161,7 +161,7 @@ class RegisterAuthorizationCommand extends Command
     protected function getDomainDirectory()
     {
         return optional(!$this->currentDomain, function ($domain) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 return app_path($this->currentDomain);
             }
             return app_path();
@@ -170,7 +170,7 @@ class RegisterAuthorizationCommand extends Command
     protected function getDomainNamespace()
     {
         return optional(!$this->currentDomain, function ($domain) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 return 'App\\' . $this->currentDomain . '\\';
             }
             return config('artify.models.namespace');
@@ -179,7 +179,7 @@ class RegisterAuthorizationCommand extends Command
     protected function getDomainModelNamespace()
     {
         return optional(!$this->currentDomain, function ($domain) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 return $this->getDomainNamespace() . 'Domain\\Models\\';
             }
             return config('artify.models.namespace');
@@ -188,7 +188,7 @@ class RegisterAuthorizationCommand extends Command
     protected function getDomainPolicyNamespace()
     {
         return optional(!$this->currentDomain, function ($domain) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 return $this->getDomainNamespace() . 'Domain\\Policies\\';
             }
             return "App\Policies\\";
@@ -229,7 +229,7 @@ class RegisterAuthorizationCommand extends Command
             $content = str_replace(['use NamespacedDummyModel;', ', DummyModel $dummyModel'], '', $originalContent);
         } else {
             $content = str_replace('use NamespacedDummyModel;', 'use ' . $this->getDomainModelNamespace() . ucfirst($model) . ';', $originalContent);
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 $content = str_replace('App\User', 'App\Users\Domain\Models\User', $content);
             }
         }
@@ -261,7 +261,7 @@ class RegisterAuthorizationCommand extends Command
     protected function getDomainPolicyDirectory()
     {
         return optional(!$this->currentDomain, function ($domain) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 return $this->getDomainDirectory() . '/Domain/Policies/';
             }
             return app_path('Policies/');

--- a/src/artifies/RepositoryMakeCommand.php
+++ b/src/artifies/RepositoryMakeCommand.php
@@ -53,13 +53,13 @@ class RepositoryMakeCommand extends Command
             return $this->error('Repository already exists');
         }
         $this->filesystem->makeDirectory(base_path($location), 0755, true, true);
-        if (config('artify.adr.enabled') && !is_dir(app_path('App/Domain/Contracts'))) {
+        if (config('artify.is_adr') && !is_dir(app_path('App/Domain/Contracts'))) {
             $contractLocation = app_path('App/Domain/Contracts/');
             $repositoryLocation = app_path('App/Domain/Repositories/');
             $this->filesystem->makeDirectory($contractLocation, 0755, true, true);
             $this->filesystem->makeDirectory($repositoryLocation, 0755, true, true);
         }
-        if (!config('artify.adr.enabled') && !is_dir(app_path('Repositories/Contracts'))) {
+        if (!config('artify.is_adr') && !is_dir(app_path('Repositories/Contracts'))) {
             $contractLocation = app_path('Repositories/Contracts/');
             $repositoryLocation = app_path('Repositories/');
             $this->filesystem->makeDirectory($contractLocation, 0755, true, true);
@@ -70,15 +70,15 @@ class RepositoryMakeCommand extends Command
         if (isset($repositoryLocation) && !$this->filesystem->exists($repositoryLocation . 'Repository.php')) {
             copy(artify_path('artifies/stubs/Repository.stub'), $repositoryLocation . 'Repository.php');
         }
-        $namespacedModel = config('artify.adr.enabled') ? $this->filesystem->getNamespaceFromLocation(substr($location, 0, strrpos($location, '/'))) . '\\Models\\' . $model : config('artify.models.namespace') . $model;
+        $namespacedModel = config('artify.is_adr') ? $this->filesystem->getNamespaceFromLocation(substr($location, 0, strrpos($location, '/'))) . '\\Models\\' . $model : config('artify.models.namespace') . $model;
         if ($this->option('model')) {
-            if (config('artify.adr.enabled')) {
+            if (config('artify.is_adr')) {
                 $this->call('make:model', [
                     'name' => $namespacedModel,
                 ]);
             }
         }
-        if (config('artify.adr.enabled')) {
+        if (config('artify.is_adr')) {
             $namespacedModel = $namespacedModel . ";\nuse App\\Domain\\Repositories\\Repository";
         }
         $defaultRepositoryContent = $this->filesystem->get(artify_path('artifies/stubs/DummyRepository.stub'));


### PR DESCRIPTION
1-  Removed deprecated trait DetectsApplicationNamespace in laravel 7 in RegisterAuthorizationCommand

2- Namespace fixed fro repositories by using lcfirst() in macro transformNamespaceToLocation

3-the adr switch unified between install command and other commands

